### PR TITLE
Update close icon with no background color to use current color

### DIFF
--- a/assets/icons/close-no-bk.svg
+++ b/assets/icons/close-no-bk.svg
@@ -2,7 +2,7 @@
 <svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>close no bk</title>
     <g id="close-no-bk" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
-        <g id="Group-13" transform="translate(12.000000, 12.000000) rotate(-315.000000) translate(-12.000000, -12.000000) translate(5.000000, 5.000000)" stroke="#FFFFFF" stroke-width="2">
+        <g id="Group-13" transform="translate(12.000000, 12.000000) rotate(-315.000000) translate(-12.000000, -12.000000) translate(5.000000, 5.000000)" stroke="currentColor" stroke-width="2">
             <line x1="0" y1="7" x2="14" y2="7" id="Line-9"></line>
             <line x1="7" y1="0" x2="7" y2="14" id="Line-9"></line>
         </g>


### PR DESCRIPTION
Allow the parent container to change the colour of the close icon.
Example:
```CSS
currentColor: purple;
```